### PR TITLE
Make Hero dashboard executable

### DIFF
--- a/launch_web_dashboard.sh
+++ b/launch_web_dashboard.sh
@@ -15,6 +15,10 @@ HERO_BRAIN_ROOT="${HERO_BRAIN_ROOT:-$HOME/brain}"
 HERO_HERMES_CONFIG="${HERO_HERMES_CONFIG:-$HOME/.hermes/config.yaml}"
 HERO_TELEGRAM_CANON="${HERO_TELEGRAM_CANON:-$HOME/wiki/queries/grok420system.md}"
 HERO_DASHBOARD_PORT="${HERO_DASHBOARD_PORT:-${PORT:-8080}}"
+if ! [[ "$HERO_DASHBOARD_PORT" =~ ^[0-9]+$ ]]; then
+    echo -e "\033[1;33m[WARN]\033[0m HERO_DASHBOARD_PORT='$HERO_DASHBOARD_PORT' is not numeric; falling back to 8080"
+    HERO_DASHBOARD_PORT=8080
+fi
 
 # Colors
 RED='\033[0;31m'

--- a/launch_web_dashboard.sh
+++ b/launch_web_dashboard.sh
@@ -14,6 +14,7 @@ HERO_WORKFLOWS_ROOT="${HERO_WORKFLOWS_ROOT:-$HOME/ORGANIZED/ACTIVE_PROJECTS/ARSE
 HERO_BRAIN_ROOT="${HERO_BRAIN_ROOT:-$HOME/brain}"
 HERO_HERMES_CONFIG="${HERO_HERMES_CONFIG:-$HOME/.hermes/config.yaml}"
 HERO_TELEGRAM_CANON="${HERO_TELEGRAM_CANON:-$HOME/wiki/queries/grok420system.md}"
+HERO_DASHBOARD_PORT="${HERO_DASHBOARD_PORT:-${PORT:-8080}}"
 
 # Colors
 RED='\033[0;31m'
@@ -79,7 +80,7 @@ check_dependencies() {
         echo "  pip install ${missing_packages[*]}"
         echo ""
         echo "Or install all web dashboard dependencies:"
-        echo "  pip install fastapi uvicorn jinja2 pyyaml>=6.0.0"
+        echo "  pip install fastapi uvicorn jinja2 'pyyaml>=6.0.0'"
         exit 1
     fi
     
@@ -147,11 +148,11 @@ start_web_dashboard() {
     
     # Set environment variables
     export PYTHONPATH="$SCRIPT_DIR:${PYTHONPATH:-}"
-    export HERO_WORKFLOWS_ROOT HERO_BRAIN_ROOT HERO_HERMES_CONFIG HERO_TELEGRAM_CANON
+    export HERO_WORKFLOWS_ROOT HERO_BRAIN_ROOT HERO_HERMES_CONFIG HERO_TELEGRAM_CANON HERO_DASHBOARD_PORT
     
-    # Check if port 8080 is available
-    if lsof -Pi :8080 -sTCP:LISTEN -t >/dev/null 2>&1; then
-        error "Port 8080 is already in use"
+    # Check if dashboard port is available
+    if lsof -Pi :"$HERO_DASHBOARD_PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
+        error "Port $HERO_DASHBOARD_PORT is already in use"
         echo "Stop the existing service or use a different port"
         return 1
     fi
@@ -170,10 +171,12 @@ start_web_dashboard() {
         
         echo ""
         echo -e "${CYAN}Web Dashboard URLs:${NC}"
-        echo "  Main Dashboard: http://localhost:8080"
-        echo "  Status JSON:    http://localhost:8080/api/status"
-        echo "  Health Check:   http://localhost:8080/api/healthz"
-        echo "  Readiness:      http://localhost:8080/api/readiness"
+        echo "  Main Dashboard: http://localhost:$HERO_DASHBOARD_PORT"
+        echo "  Status JSON:    http://localhost:$HERO_DASHBOARD_PORT/api/status"
+        echo "  Labyrinth JSON: http://localhost:$HERO_DASHBOARD_PORT/api/labyrinth"
+        echo "  Actions JSON:   http://localhost:$HERO_DASHBOARD_PORT/api/actions"
+        echo "  Health Check:   http://localhost:$HERO_DASHBOARD_PORT/api/healthz"
+        echo "  Readiness:      http://localhost:$HERO_DASHBOARD_PORT/api/readiness"
         echo ""
         echo -e "${GREEN}Dashboard is running with honest subsystem probes${NC}"
         echo -e "${YELLOW}Press Ctrl+C to stop or use './launch_web_dashboard.sh stop'${NC}"
@@ -232,7 +235,7 @@ show_status() {
         fi
         if kill -0 "$pid" 2>/dev/null && pid_matches_dashboard "$pid"; then
             echo "  [OK] Running (PID: $pid)"
-            echo "  URL: http://localhost:8080"
+            echo "  URL: http://localhost:$HERO_DASHBOARD_PORT"
 
             # Show recent log entries
             if [[ -f "$LOG_DIR/web_dashboard.log" ]]; then
@@ -359,7 +362,7 @@ show_logs() {
 open_browser() {
     if command -v open &> /dev/null; then
         sleep 2
-        open "http://localhost:8080"
+        open "http://localhost:$HERO_DASHBOARD_PORT"
         info "Opening dashboard in browser"
     fi
 }

--- a/tests/test_web_dashboard_reboot.py
+++ b/tests/test_web_dashboard_reboot.py
@@ -8,16 +8,23 @@ from fastapi.testclient import TestClient
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from web_dashboard import (
+    ACTION_REGISTRY,
     DashboardRuntime,
     app,
     build_alerts,
+    build_labyrinth,
     env_int,
     env_path,
+    execute_action,
+    list_actions,
     make_probe,
     parse_topic_ownership,
+    preview_lines,
+    read_action_events,
     sanitize_url,
     summarize_factory_models,
     redact_process_line,
+    redact_text,
 )
 
 
@@ -184,3 +191,144 @@ def test_probe_droids_degraded_when_bridge_missing(monkeypatch, tmp_path):
     assert "droid_processes" not in probe["details"]
     assert "factory_processes" not in probe["details"]
     assert "Hermes Factory model" in probe["last_error"]
+
+
+def test_action_registry_is_public_and_allowlisted():
+    actions = list_actions()
+    ids = {action["id"] for action in actions}
+
+    assert {"refresh_status", "compile_dashboard", "run_reboot_tests", "launcher_status", "tail_logs"}.issubset(ids)
+    assert all("args" not in action for action in actions)
+    assert ACTION_REGISTRY["compile_dashboard"]["args"] == ["python3", "-m", "py_compile", "web_dashboard.py", "config.py"]
+
+
+def test_redact_text_scrubs_common_secret_shapes():
+    raw = "token=supersecret Authorization: Bearer abcdefghijklmnop https://user:pass@example.com/path?api_key=hidden"
+    redacted = redact_text(raw)
+
+    assert "supersecret" not in redacted
+    assert "abcdefghijklmnop" not in redacted
+    assert "user:pass" not in redacted
+    assert "hidden" not in redacted
+
+
+def test_preview_lines_keeps_tail_and_redacts():
+    preview = preview_lines("one\ntwo\npassword=secret\nthree", max_lines=2)
+
+    assert "one" not in preview
+    assert "secret" not in preview
+    assert "password=[redacted]" in preview
+
+
+def test_read_action_events_ignores_bad_lines(monkeypatch, tmp_path):
+    import web_dashboard
+
+    action_log = tmp_path / "actions.jsonl"
+    action_log.write_text('not-json\n{"id": "ok", "status": "succeeded"}\n')
+    monkeypatch.setattr(web_dashboard, "HERO_ACTION_LOG", action_log)
+
+    assert read_action_events() == [{"id": "ok", "status": "succeeded"}]
+
+
+def test_execute_action_records_redacted_command_output(monkeypatch, tmp_path):
+    import subprocess
+    import web_dashboard
+
+    monkeypatch.setattr(web_dashboard, "HERO_HOME", tmp_path)
+    monkeypatch.setattr(web_dashboard, "HERO_ACTION_LOG", tmp_path / "actions.jsonl")
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="api_key=secret-token", stderr="")
+
+    monkeypatch.setattr(web_dashboard.subprocess, "run", fake_run)
+
+    event = execute_action("compile_dashboard")
+
+    assert event["status"] == "succeeded"
+    assert "secret-token" not in event["stdout_preview"]
+    assert (tmp_path / "actions.jsonl").exists()
+
+
+def test_api_actions_and_unknown_action(monkeypatch):
+    import web_dashboard
+
+    client = TestClient(app)
+    monkeypatch.setattr(web_dashboard, "read_action_events", lambda limit=20: [])
+
+    actions = client.get("/api/actions")
+    missing = client.post("/api/actions/not-real")
+
+    assert actions.status_code == 200
+    assert any(action["id"] == "compile_dashboard" for action in actions.json()["actions"])
+    assert missing.status_code == 404
+
+
+def test_api_run_action_uses_allowlisted_executor(monkeypatch):
+    import web_dashboard
+
+    client = TestClient(app)
+    monkeypatch.setattr(
+        web_dashboard,
+        "execute_action",
+        lambda action_id: {
+            "id": "action-test",
+            "action_id": action_id,
+            "label": "Compile Dashboard",
+            "status": "succeeded",
+            "exit_code": 0,
+            "duration_ms": 4,
+            "stdout_preview": "ok",
+            "stderr_preview": "",
+        },
+    )
+
+    response = client.post("/api/actions/compile_dashboard")
+
+    assert response.status_code == 200
+    assert response.json()["action_id"] == "compile_dashboard"
+
+
+def test_build_labyrinth_includes_probe_crossings_and_failed_action(monkeypatch):
+    import web_dashboard
+
+    snapshot = {
+        "overview": {"timestamp": "2026-04-28T00:00:00Z"},
+        "card_order": ["hermes", "droids", "telegram", "gbrain", "workflows", "alerts"],
+        "cards": {
+            "hermes": make_probe(name="hermes", status="healthy", source="test", details={}),
+            "droids": make_probe(name="droids", status="degraded", source="test", details={}, last_error="bridge missing"),
+            "telegram": make_probe(name="telegram", status="healthy", source="test", details={}),
+            "gbrain": make_probe(name="gbrain", status="healthy", source="test", details={}),
+            "workflows": make_probe(name="workflows", status="healthy", source="test", details={}),
+            "alerts": make_probe(name="alerts", status="degraded", source="test", details={"summary": "1 alert"}, last_error="bridge missing"),
+        },
+    }
+    monkeypatch.setattr(
+        web_dashboard,
+        "read_action_events",
+        lambda limit=25: [
+            {
+                "id": "action-1",
+                "action_id": "compile_dashboard",
+                "label": "Compile Dashboard",
+                "status": "failed",
+                "exit_code": 1,
+                "duration_ms": 10,
+                "started_at": "2026-04-28T00:00:01Z",
+                "completed_at": "2026-04-28T00:00:02Z",
+                "stderr_preview": "password=[redacted]",
+                "stdout_preview": "",
+                "command": ["python3"],
+                "cwd": "/tmp",
+            }
+        ],
+    )
+    monkeypatch.setattr(web_dashboard, "discover_skill_inventory", lambda limit=60: [{"name": "taste", "namespace": "agents"}])
+    monkeypatch.setattr(web_dashboard, "cron_gate_snapshot", lambda: [{"name": "cron.yaml", "status": "missing"}])
+
+    payload = build_labyrinth(snapshot)
+
+    assert payload["journeys"][0]["id"] == "journey-current-dashboard"
+    assert any(crossing["id"] == "crossing-probe-droids" for crossing in payload["crossings"])
+    assert any(guidepost["title"] == "Compile Dashboard failed" for guidepost in payload["guideposts"])
+    assert "password=[redacted]" in str(payload)

--- a/web_dashboard.py
+++ b/web_dashboard.py
@@ -335,7 +335,7 @@ def execute_action(action_id: str) -> dict[str, Any]:
     except subprocess.TimeoutExpired as exc:
         status = "failed"
         exit_code = 124
-        stdout = exc.stdout or ""
+        stdout = exc.stdout.decode("utf-8", errors="replace") if isinstance(exc.stdout, bytes) else (exc.stdout or "")
         stderr = f"Action timed out after {spec.get('timeout', 30)}s"
     except Exception as exc:  # pragma: no cover - defensive
         status = "failed"

--- a/web_dashboard.py
+++ b/web_dashboard.py
@@ -1078,12 +1078,14 @@ async def api_status() -> JSONResponse:
 
 @app.get("/api/actions")
 async def api_actions() -> JSONResponse:
-    return JSONResponse({"actions": list_actions(), "history": read_action_events(8)})
+    history = await run_in_threadpool(read_action_events, 8)
+    return JSONResponse({"actions": list_actions(), "history": history})
 
 
 @app.get("/api/actions/history")
 async def api_actions_history() -> JSONResponse:
-    return JSONResponse({"events": read_action_events(50)})
+    events = await run_in_threadpool(read_action_events, 50)
+    return JSONResponse({"events": events})
 
 
 @app.post("/api/actions/{action_id}")

--- a/web_dashboard.py
+++ b/web_dashboard.py
@@ -861,7 +861,7 @@ def status_weight(status: str) -> int:
 
 def discover_skill_inventory(limit: int = 60) -> list[dict[str, Any]]:
     now = time.monotonic()
-    if SKILL_CACHE["items"] and now - SKILL_CACHE["timestamp"] < 300:
+    if SKILL_CACHE["timestamp"] and now - SKILL_CACHE["timestamp"] < 300:
         return SKILL_CACHE["items"][:limit]
 
     inventory: list[dict[str, Any]] = []

--- a/web_dashboard.py
+++ b/web_dashboard.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import socket
 import subprocess
+import time
 from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -18,7 +19,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit, urlunsplit
 from urllib.request import Request, urlopen
 
-from fastapi import FastAPI, Request as FastAPIRequest
+from fastapi import FastAPI, HTTPException, Request as FastAPIRequest
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 from starlette.concurrency import run_in_threadpool
@@ -36,6 +37,8 @@ ROOT = Path(__file__).resolve().parent
 TEMPLATES_DIR = ROOT / "web_templates"
 HERO_HOME = Path.home() / ".hero_core"
 HERO_CACHE = HERO_HOME / "cache"
+HERO_LOGS = HERO_HOME / "logs"
+HERO_ACTION_LOG = HERO_HOME / "actions.jsonl"
 HERMES_HOME = Path.home() / ".hermes"
 
 
@@ -64,8 +67,50 @@ MAIN_HERMES_CONFIG = env_path("HERO_HERMES_CONFIG", HERMES_HOME / "config.yaml")
 PORT_WEBAPI = env_int("HERO_WEBAPI_PORT", 8642)
 PORT_WORKSPACE = env_int("HERO_WORKSPACE_PORT", 3011)
 DROID_BRIDGE_PORT = env_int("HERO_DROID_BRIDGE_PORT", 8645)
+DASHBOARD_PORT = env_int("HERO_DASHBOARD_PORT", env_int("PORT", 8080))
 FACTORY_SETTINGS_PATH = env_path("HERO_FACTORY_SETTINGS", Path.home() / ".factory" / "settings.json")
 CARD_ORDER = ["hermes", "droids", "telegram", "gbrain", "workflows", "alerts"]
+ACTION_REGISTRY: OrderedDict[str, dict[str, Any]] = OrderedDict(
+    {
+        "refresh_status": {
+            "label": "Refresh Status",
+            "description": "Re-run all local probes and return the current subsystem snapshot.",
+            "kind": "internal",
+            "tone": "neutral",
+        },
+        "compile_dashboard": {
+            "label": "Compile Dashboard",
+            "description": "Parse the FastAPI dashboard and config modules with Python bytecode compilation.",
+            "kind": "command",
+            "args": ["python3", "-m", "py_compile", "web_dashboard.py", "config.py"],
+            "timeout": 25,
+            "tone": "healthy",
+        },
+        "run_reboot_tests": {
+            "label": "Run Reboot Tests",
+            "description": "Execute the focused Hero reboot dashboard pytest suite.",
+            "kind": "command",
+            "args": ["python3", "-m", "pytest", "-q", "tests/test_web_dashboard_reboot.py"],
+            "timeout": 90,
+            "tone": "healthy",
+        },
+        "launcher_status": {
+            "label": "Launcher Status",
+            "description": "Ask the launcher script whether the background dashboard process is running.",
+            "kind": "command",
+            "args": ["bash", "launch_web_dashboard.sh", "status"],
+            "timeout": 20,
+            "tone": "neutral",
+        },
+        "tail_logs": {
+            "label": "Tail Logs",
+            "description": "Read recent dashboard logs from ~/.hero_core/logs without spawning a shell.",
+            "kind": "internal",
+            "tone": "stale",
+        },
+    }
+)
+SKILL_CACHE: dict[str, Any] = {"timestamp": 0.0, "items": []}
 FRESHNESS_THRESHOLDS = {
     "hermes": 60,
     "droids": 60,
@@ -103,6 +148,26 @@ def sanitize_url(url: str | None) -> str | None:
     if parts.port:
         netloc = f"{host}:{parts.port}"
     return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+
+
+def redact_text(value: str | None, limit: int = 5000) -> str:
+    if not value:
+        return ""
+    text = value[:limit]
+    text = re.sub(r"https?://[^:\s/@]+:[^@\s/]+@", "https://[redacted]@", text)
+    text = re.sub(r"(?i)(bearer|basic)\s+[A-Za-z0-9._~+/=-]{12,}", r"\1 [redacted]", text)
+    text = re.sub(r"(?i)(api[_-]?key|token|password|secret|authorization)(\s*[=:]\s*)[^\s,;]+", r"\1\2[redacted]", text)
+    text = re.sub(r"(?i)([?&](?:token|key|secret|password|api_key)=)[^&\s]+", r"\1[redacted]", text)
+    text = re.sub(r"\b[A-Za-z0-9_/-]{36,}\b", "[redacted-long-token]", text)
+    return text
+
+
+def preview_lines(value: str | None, max_lines: int = 80, max_chars: int = 5000) -> str:
+    redacted = redact_text(value, limit=max_chars)
+    lines = redacted.splitlines()
+    if len(lines) > max_lines:
+        lines = lines[-max_lines:]
+    return "\n".join(lines)
 
 
 def try_load_yaml(path: Path) -> dict[str, Any]:
@@ -174,6 +239,127 @@ def run_command(args: list[str], timeout: float = 2.0) -> tuple[int, str, str]:
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
         return 127, "", str(exc)
     return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+
+def action_public_payload(action_id: str, spec: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": action_id,
+        "label": spec["label"],
+        "description": spec["description"],
+        "kind": spec["kind"],
+        "tone": spec.get("tone", "neutral"),
+        "timeout": spec.get("timeout"),
+    }
+
+
+def list_actions() -> list[dict[str, Any]]:
+    return [action_public_payload(action_id, spec) for action_id, spec in ACTION_REGISTRY.items()]
+
+
+def append_action_event(event: dict[str, Any]) -> None:
+    HERO_HOME.mkdir(parents=True, exist_ok=True)
+    with HERO_ACTION_LOG.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, sort_keys=True) + "\n")
+
+
+def read_action_events(limit: int = 20) -> list[dict[str, Any]]:
+    if not HERO_ACTION_LOG.exists():
+        return []
+    lines = HERO_ACTION_LOG.read_text(encoding="utf-8", errors="replace").splitlines()
+    events: list[dict[str, Any]] = []
+    for line in lines[-limit:]:
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            events.append(parsed)
+    return events
+
+
+def tail_dashboard_logs(max_lines: int = 80) -> tuple[str, str]:
+    candidates = [
+        HERO_LOGS / "web_dashboard.log",
+        HERO_LOGS / "herodash-main-live.log",
+    ]
+    chunks = []
+    for path in candidates:
+        if not path.exists():
+            continue
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()[-max_lines:]
+        chunks.append(f"==> {path}\n" + "\n".join(lines))
+    if not chunks:
+        return "", "No dashboard logs found in ~/.hero_core/logs"
+    return "\n\n".join(chunks), ""
+
+
+def execute_action(action_id: str) -> dict[str, Any]:
+    spec = ACTION_REGISTRY.get(action_id)
+    if not spec:
+        raise KeyError(action_id)
+
+    started = time.monotonic()
+    started_at = iso_now()
+    status = "succeeded"
+    exit_code = 0
+    stdout = ""
+    stderr = ""
+
+    try:
+        if action_id == "refresh_status":
+            current = runtime.snapshot()
+            stdout = json.dumps(
+                {
+                    "timestamp": current["overview"]["timestamp"],
+                    "cards": {name: current["cards"][name]["status"] for name in current["card_order"]},
+                },
+                indent=2,
+            )
+        elif action_id == "tail_logs":
+            stdout, stderr = tail_dashboard_logs()
+            exit_code = 0 if stdout else 1
+            status = "succeeded" if stdout else "failed"
+        else:
+            result = subprocess.run(
+                spec["args"],
+                cwd=str(ROOT),
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=spec.get("timeout", 30),
+            )
+            exit_code = result.returncode
+            stdout = result.stdout or ""
+            stderr = result.stderr or ""
+            status = "succeeded" if exit_code == 0 else "failed"
+    except subprocess.TimeoutExpired as exc:
+        status = "failed"
+        exit_code = 124
+        stdout = exc.stdout or ""
+        stderr = f"Action timed out after {spec.get('timeout', 30)}s"
+    except Exception as exc:  # pragma: no cover - defensive
+        status = "failed"
+        exit_code = 1
+        stderr = f"{type(exc).__name__}: {exc}"
+
+    completed_at = iso_now()
+    duration_ms = int((time.monotonic() - started) * 1000)
+    event = {
+        "id": f"action-{int(time.time() * 1000)}-{action_id}",
+        "action_id": action_id,
+        "label": spec["label"],
+        "status": status,
+        "exit_code": exit_code,
+        "started_at": started_at,
+        "completed_at": completed_at,
+        "duration_ms": duration_ms,
+        "cwd": str(ROOT),
+        "command": spec.get("args", [action_id]),
+        "stdout_preview": preview_lines(stdout),
+        "stderr_preview": preview_lines(stderr),
+    }
+    append_action_event(event)
+    return event
 
 
 def port_open(port: int, host: str = "127.0.0.1", timeout: float = 0.35) -> bool:
@@ -669,6 +855,206 @@ class DashboardRuntime:
         }
 
 
+def status_weight(status: str) -> int:
+    return {"healthy": 0, "succeeded": 0, "stale": 1, "degraded": 2, "failed": 2, "down": 3}.get(status, 2)
+
+
+def discover_skill_inventory(limit: int = 60) -> list[dict[str, Any]]:
+    now = time.monotonic()
+    if SKILL_CACHE["items"] and now - SKILL_CACHE["timestamp"] < 300:
+        return SKILL_CACHE["items"][:limit]
+
+    inventory: list[dict[str, Any]] = []
+    roots = [Path.home() / ".agents" / "skills", Path.home() / ".codex" / "skills"]
+    for root in roots:
+        if not root.exists():
+            continue
+        queue: list[tuple[Path, int]] = [(root, 0)]
+        while queue and len(inventory) < limit:
+            directory, depth = queue.pop(0)
+            skill_file = directory / "SKILL.md"
+            if not skill_file.exists():
+                if depth >= 4:
+                    continue
+                try:
+                    children = sorted(
+                        child
+                        for child in directory.iterdir()
+                        if child.is_dir() and child.name not in {".git", "__pycache__", "node_modules", ".venv", "cache"}
+                    )
+                except OSError:
+                    children = []
+                queue.extend((child, depth + 1) for child in children)
+                continue
+            try:
+                rel = skill_file.relative_to(root).parent.as_posix()
+                text = skill_file.read_text(encoding="utf-8", errors="replace")[:900]
+            except OSError:
+                continue
+            name_match = re.search(r"^name:\s*(.+)$", text, flags=re.MULTILINE)
+            desc_match = re.search(r"^description:\s*(.+)$", text, flags=re.MULTILINE)
+            description = desc_match.group(1).strip() if desc_match else "local skill"
+            if description == "|":
+                description = "local skill"
+            inventory.append(
+                {
+                    "name": (name_match.group(1).strip() if name_match else rel.split("/")[-1]),
+                    "namespace": root.parent.name,
+                    "path": str(skill_file),
+                    "description": description,
+                    "timestamp": file_timestamp(skill_file),
+                }
+            )
+            if depth < 4:
+                try:
+                    children = sorted(
+                        child
+                        for child in directory.iterdir()
+                        if child.is_dir() and child.name not in {".git", "__pycache__", "node_modules", ".venv", "cache"}
+                    )
+                except OSError:
+                    children = []
+                queue.extend((child, depth + 1) for child in children)
+    SKILL_CACHE["timestamp"] = now
+    SKILL_CACHE["items"] = inventory
+    return inventory
+
+
+def cron_gate_snapshot() -> list[dict[str, Any]]:
+    candidates = [
+        HERMES_HOME / "cron.yaml",
+        HERMES_HOME / "cron.yml",
+        HERMES_HOME / "crontab.yaml",
+        HERO_HOME / "cron.yaml",
+    ]
+    gates: list[dict[str, Any]] = []
+    for path in candidates:
+        gates.append(
+            {
+                "name": path.name,
+                "path": str(path),
+                "status": "configured" if path.exists() else "missing",
+                "timestamp": file_timestamp(path),
+            }
+        )
+    return gates
+
+
+def build_labyrinth(snapshot: dict[str, Any] | None = None) -> dict[str, Any]:
+    current = snapshot or runtime.snapshot()
+    now = current["overview"]["timestamp"]
+    action_events = read_action_events(25)
+
+    journeys: list[dict[str, Any]] = [
+        {
+            "id": "journey-current-dashboard",
+            "title": "Hero dashboard live probe",
+            "source": "dashboard",
+            "status": current["cards"]["alerts"]["status"],
+            "started_at": now,
+            "updated_at": now,
+            "summary": current["cards"]["alerts"]["details"]["summary"],
+        }
+    ]
+    crossings: list[dict[str, Any]] = []
+    guideposts: list[dict[str, Any]] = []
+
+    for index, name in enumerate(current["card_order"]):
+        card = current["cards"][name]
+        crossing = {
+            "id": f"crossing-probe-{name}",
+            "journey_id": "journey-current-dashboard",
+            "thread": "main" if name != "alerts" else "thresholds",
+            "type": "probe",
+            "label": name,
+            "status": card["status"],
+            "timestamp": card["timestamp"],
+            "duration_ms": None,
+            "summary": card.get("last_error") or card.get("source"),
+            "evidence": {
+                "source": card.get("source"),
+                "freshness_seconds": card.get("freshness_seconds"),
+                "details": card.get("details", {}),
+            },
+            "weight": status_weight(card["status"]),
+            "order": index,
+        }
+        crossings.append(crossing)
+        if card["status"] != "healthy":
+            guideposts.append(
+                {
+                    "id": f"guidepost-{name}",
+                    "severity": card["status"],
+                    "title": f"{name} needs attention",
+                    "summary": card.get("last_error") or f"{name} is {card['status']}",
+                    "evidence_crossing_id": crossing["id"],
+                    "timestamp": card["timestamp"],
+                }
+            )
+
+    for index, event in enumerate(reversed(action_events)):
+        journey_id = f"journey-{event['id']}"
+        journeys.append(
+            {
+                "id": journey_id,
+                "title": event.get("label") or event.get("action_id"),
+                "source": "operator-action",
+                "status": event.get("status", "unknown"),
+                "started_at": event.get("started_at"),
+                "updated_at": event.get("completed_at"),
+                "summary": f"exit {event.get('exit_code')} in {event.get('duration_ms')}ms",
+            }
+        )
+        crossings.append(
+            {
+                "id": f"crossing-{event['id']}",
+                "journey_id": journey_id,
+                "thread": "tools",
+                "type": "action",
+                "label": event.get("label") or event.get("action_id"),
+                "status": event.get("status", "unknown"),
+                "timestamp": event.get("completed_at"),
+                "duration_ms": event.get("duration_ms"),
+                "summary": event.get("stderr_preview") or event.get("stdout_preview") or "action completed",
+                "evidence": {
+                    "command": event.get("command"),
+                    "stdout_preview": event.get("stdout_preview"),
+                    "stderr_preview": event.get("stderr_preview"),
+                    "cwd": event.get("cwd"),
+                },
+                "weight": status_weight(event.get("status", "unknown")),
+                "order": len(crossings) + index,
+            }
+        )
+        if event.get("status") != "succeeded":
+            guideposts.append(
+                {
+                    "id": f"guidepost-{event['id']}",
+                    "severity": "degraded",
+                    "title": f"{event.get('label')} failed",
+                    "summary": event.get("stderr_preview") or "operator action failed",
+                    "evidence_crossing_id": f"crossing-{event['id']}",
+                    "timestamp": event.get("completed_at"),
+                }
+            )
+
+    crossings.sort(key=lambda item: (item.get("timestamp") or "", item.get("order") or 0))
+    return {
+        "generated_at": now,
+        "source": "hero-dashboard-local-runtime",
+        "journeys": journeys[:30],
+        "crossings": crossings[-80:],
+        "guideposts": sorted(guideposts, key=lambda item: status_weight(item["severity"]), reverse=True)[:30],
+        "skills": discover_skill_inventory(),
+        "cron": cron_gate_snapshot(),
+        "actions": list_actions(),
+        "reports": {
+            "json": "/api/labyrinth",
+            "action_history": "/api/actions/history",
+        },
+    }
+
+
 app = FastAPI(title="Hero Reboot Dashboard", description="Honest operator surface for Hermes, Telegram, GBrain, and WORKFLOWS")
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 runtime = DashboardRuntime()
@@ -690,6 +1076,31 @@ async def api_status() -> JSONResponse:
     return JSONResponse(snapshot)
 
 
+@app.get("/api/actions")
+async def api_actions() -> JSONResponse:
+    return JSONResponse({"actions": list_actions(), "history": read_action_events(8)})
+
+
+@app.get("/api/actions/history")
+async def api_actions_history() -> JSONResponse:
+    return JSONResponse({"events": read_action_events(50)})
+
+
+@app.post("/api/actions/{action_id}")
+async def api_run_action(action_id: str) -> JSONResponse:
+    if action_id not in ACTION_REGISTRY:
+        raise HTTPException(status_code=404, detail=f"Unknown action: {action_id}")
+    event = await run_in_threadpool(execute_action, action_id)
+    status_code = 200 if event["status"] == "succeeded" else 500
+    return JSONResponse(event, status_code=status_code)
+
+
+@app.get("/api/labyrinth")
+async def api_labyrinth() -> JSONResponse:
+    payload = await run_in_threadpool(build_labyrinth)
+    return JSONResponse(payload)
+
+
 @app.get("/api/healthz")
 async def healthz() -> JSONResponse:
     # Return cheap process-alive response without expensive snapshot
@@ -702,6 +1113,16 @@ async def healthz() -> JSONResponse:
         },
         status_code=200,
     )
+
+
+@app.get("/health")
+async def health_alias() -> JSONResponse:
+    return await healthz()
+
+
+@app.get("/api/version")
+async def api_version() -> JSONResponse:
+    return JSONResponse({"version": "hero-reboot-v2", "dashboard_port": DASHBOARD_PORT, "timestamp": iso_now()})
 
 
 @app.get("/api/readiness")
@@ -720,8 +1141,8 @@ async def readiness() -> JSONResponse:
 
 
 def main() -> None:
-    logger.info("Starting Hero reboot dashboard on http://127.0.0.1:8080")
-    uvicorn.run(app, host="127.0.0.1", port=8080, log_level="info")
+    logger.info("Starting Hero reboot dashboard on http://127.0.0.1:%s", DASHBOARD_PORT)
+    uvicorn.run(app, host="127.0.0.1", port=DASHBOARD_PORT, log_level="info")
 
 
 if __name__ == "__main__":

--- a/web_templates/dashboard.html
+++ b/web_templates/dashboard.html
@@ -27,6 +27,7 @@
       --mono: "Geist Mono", "SFMono-Regular", "Menlo", "Monaco", "Consolas", monospace;
       --sans: "Geist", "Outfit", "Avenir Next", ui-sans-serif, system-ui, sans-serif;
       --ease: cubic-bezier(0.22, 1, 0.36, 1);
+      --ease-heavy: cubic-bezier(0.32, 0.72, 0, 1);
     }
 
     * { box-sizing: border-box; }
@@ -175,6 +176,11 @@
     }
 
     .pill:active { transform: translateY(0) scale(0.98); }
+
+    .pillbutton {
+      appearance: none;
+      cursor: pointer;
+    }
 
     .hero {
       display: grid;
@@ -585,6 +591,272 @@
       font-size: 0.92rem;
     }
 
+    .operator-grid {
+      display: grid;
+      grid-template-columns: minmax(320px, 0.72fr) minmax(0, 1.28fr);
+      gap: 16px;
+      margin-top: 16px;
+      align-items: stretch;
+      min-width: 0;
+    }
+
+    .section-shell {
+      border: 1px solid var(--line);
+      border-radius: 28px;
+      padding: 6px;
+      background: rgba(255,255,255,0.052);
+      box-shadow: 0 18px 50px rgba(0,0,0,0.18), inset 0 1px 0 rgba(255,255,255,0.1);
+      animation: fadeUp 900ms var(--ease) both;
+      min-width: 0;
+    }
+
+    .section-core {
+      min-height: 100%;
+      border-radius: 22px;
+      padding: clamp(18px, 2vw, 26px);
+      background:
+        radial-gradient(circle at top right, rgba(119,214,167,0.08), transparent 16rem),
+        var(--core);
+      box-shadow: inset 0 1px 1px rgba(255,255,255,0.12);
+      min-width: 0;
+    }
+
+    .section-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      align-items: flex-start;
+      margin-bottom: 18px;
+      min-width: 0;
+    }
+
+    .section-head h2 {
+      margin: 0;
+      font-size: clamp(1.3rem, 2.1vw, 2rem);
+      line-height: 1;
+    }
+
+    .section-head p {
+      max-width: 680px;
+      margin: 8px 0 0;
+      color: var(--muted);
+      line-height: 1.5;
+    }
+
+    .action-list {
+      display: grid;
+      gap: 10px;
+    }
+
+    .action-button {
+      width: 100%;
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 12px;
+      align-items: center;
+      min-width: 0;
+      min-height: 74px;
+      padding: 12px;
+      border: 1px solid rgba(255,255,255,0.11);
+      border-radius: 18px;
+      color: var(--ink);
+      background: rgba(255,255,255,0.045);
+      text-align: left;
+      cursor: pointer;
+      transition: transform 700ms var(--ease-heavy), background 700ms var(--ease-heavy), border-color 700ms var(--ease-heavy);
+    }
+
+    .action-button:hover {
+      transform: translateY(-2px);
+      border-color: var(--line-strong);
+      background: rgba(255,255,255,0.074);
+    }
+
+    .action-button:active { transform: translateY(0) scale(0.985); }
+    .action-button[disabled] { cursor: wait; opacity: 0.68; transform: none; }
+
+    .action-button strong {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 0.98rem;
+      overflow-wrap: anywhere;
+    }
+
+    .action-button span {
+      display: block;
+      min-width: 0;
+      color: var(--muted);
+      font-size: 0.82rem;
+      line-height: 1.35;
+      overflow-wrap: anywhere;
+    }
+
+    .action-icon {
+      display: grid;
+      place-items: center;
+      width: 38px;
+      height: 38px;
+      border-radius: 50%;
+      background: rgba(255,255,255,0.08);
+      color: var(--healthy);
+      font-family: var(--mono);
+      transition: transform 700ms var(--ease-heavy), background 700ms var(--ease-heavy);
+    }
+
+    .action-button:hover .action-icon { transform: translateX(2px) translateY(-1px); }
+
+    .action-result {
+      margin-top: 14px;
+      padding: 13px;
+      border: 1px solid rgba(255,255,255,0.11);
+      border-radius: 18px;
+      background: rgba(255,255,255,0.04);
+      min-height: 94px;
+    }
+
+    .action-result pre,
+    .inspector pre {
+      max-height: 260px;
+      overflow: auto;
+      margin: 10px 0 0;
+      white-space: pre-wrap;
+      color: #dfe6ef;
+      font-family: var(--mono);
+      font-size: 0.76rem;
+      line-height: 1.52;
+    }
+
+    .labyrinth-layout {
+      display: grid;
+      grid-template-columns: minmax(0, 1.18fr) minmax(280px, 0.82fr);
+      gap: 14px;
+      align-items: start;
+      min-width: 0;
+    }
+
+    .journey-strip {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 0 0 10px;
+      margin-bottom: 14px;
+    }
+
+    .journey-chip,
+    .crossing {
+      border: 1px solid rgba(255,255,255,0.11);
+      background: rgba(255,255,255,0.045);
+      color: var(--ink);
+      cursor: pointer;
+      transition: transform 700ms var(--ease-heavy), border-color 700ms var(--ease-heavy), background 700ms var(--ease-heavy);
+    }
+
+    .journey-chip {
+      flex: 0 0 220px;
+      padding: 12px;
+      border-radius: 18px;
+      text-align: left;
+    }
+
+    .journey-chip:hover,
+    .crossing:hover,
+    .crossing.selected {
+      transform: translateY(-2px);
+      border-color: var(--line-strong);
+      background: rgba(255,255,255,0.072);
+    }
+
+    .journey-chip strong,
+    .crossing strong {
+      display: block;
+      margin-bottom: 8px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .journey-chip small,
+    .crossing small {
+      display: block;
+      color: var(--muted);
+      font-family: var(--mono);
+      font-size: 0.68rem;
+      line-height: 1.45;
+    }
+
+    .crossing-list {
+      display: grid;
+      gap: 8px;
+      max-height: 640px;
+      overflow: auto;
+      padding-right: 4px;
+    }
+
+    .crossing {
+      width: 100%;
+      display: grid;
+      grid-template-columns: 86px 1fr auto;
+      gap: 10px;
+      align-items: center;
+      min-height: 66px;
+      padding: 10px;
+      border-radius: 17px;
+      text-align: left;
+    }
+
+    .thread {
+      color: var(--sand);
+      font-family: var(--mono);
+      font-size: 0.68rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+    }
+
+    .inspector {
+      position: sticky;
+      top: 96px;
+      min-height: 360px;
+      padding: 14px;
+      border: 1px solid rgba(255,255,255,0.11);
+      border-radius: 20px;
+      background: rgba(255,255,255,0.045);
+    }
+
+    .guidepost-list,
+    .atlas-list {
+      display: grid;
+      gap: 8px;
+      margin-top: 14px;
+      max-height: 300px;
+      overflow: auto;
+    }
+
+    .guidepost,
+    .atlas-item {
+      padding: 11px;
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 15px;
+      background: rgba(255,255,255,0.04);
+      line-height: 1.42;
+    }
+
+    .guidepost strong,
+    .atlas-item strong { display: block; margin-bottom: 5px; }
+    .guidepost p,
+    .atlas-item p { margin: 0; color: var(--muted); font-size: 0.84rem; }
+
+    .atlas-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+      margin-top: 16px;
+      min-width: 0;
+    }
+
+    .operator-grid > *,
+    .labyrinth-layout > *,
+    .atlas-grid > * { min-width: 0; }
+
     code {
       color: var(--accent);
       font-family: var(--mono);
@@ -635,6 +907,10 @@
       .card-shell.telegram,
       .card-shell.gbrain,
       .card-shell.workflows { grid-column: 1 / -1; }
+      .operator-grid,
+      .labyrinth-layout,
+      .atlas-grid { grid-template-columns: 1fr; }
+      .inspector { position: static; }
       .alert-items { grid-template-columns: 1fr; }
     }
 
@@ -662,7 +938,8 @@
 
       .nav-actions,
       .pill,
-      .button {
+      .button,
+      .action-button {
         width: 100%;
         justify-content: space-between;
       }
@@ -679,6 +956,16 @@
       .grid { gap: 10px; }
       .card-shell { min-height: 0; }
       .micro-grid { grid-template-columns: 1fr; }
+      .section-head { flex-direction: column; }
+      .crossing { grid-template-columns: 1fr; }
+      .journey-strip {
+        overflow: visible;
+        flex-direction: column;
+      }
+      .journey-chip {
+        width: 100%;
+        flex-basis: auto;
+      }
     }
   </style>
 </head>
@@ -694,6 +981,7 @@
       </div>
       <div class="nav-actions">
         <a class="pill" href="/api/status">status json</a>
+        <a class="pill" href="/api/labyrinth">labyrinth json</a>
         <a class="pill" href="/api/readiness">readiness</a>
       </div>
     </nav>
@@ -721,8 +1009,72 @@
 
     <section id="cards" class="grid" aria-label="Subsystem cards"></section>
 
+    <section class="operator-grid" aria-label="Executable dashboard controls">
+      <div class="section-shell">
+        <div class="section-core">
+          <div class="section-head">
+            <div>
+              <div class="eyebrow">action dock</div>
+              <h2>Run the safe checks.</h2>
+              <p>Every control is allowlisted server-side and writes a redacted audit event.</p>
+            </div>
+          </div>
+          <div id="action-list" class="action-list"></div>
+          <div id="action-result" class="action-result">
+            <span class="source">No action run in this browser session yet.</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="section-shell">
+        <div class="section-core">
+          <div class="section-head">
+            <div>
+              <div class="eyebrow">labyrinth map</div>
+              <h2>Journeys, crossings, evidence.</h2>
+              <p>Live probes and executable actions are normalized into a timeline with guideposts.</p>
+            </div>
+            <button class="pill pillbutton" id="labyrinth-refresh" type="button">refresh map</button>
+          </div>
+          <div id="journey-strip" class="journey-strip"></div>
+          <div class="labyrinth-layout">
+            <div id="crossing-list" class="crossing-list"></div>
+            <aside id="inspector" class="inspector" aria-label="Crossing inspector"></aside>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="atlas-grid" aria-label="Skill and cron inventory">
+      <div class="section-shell">
+        <div class="section-core">
+          <div class="section-head">
+            <div>
+              <div class="eyebrow">skill atlas</div>
+              <h2>Local operator skills.</h2>
+            </div>
+            <span class="status status-stale" id="skill-count">0</span>
+          </div>
+          <div id="skill-atlas" class="atlas-list"></div>
+        </div>
+      </div>
+      <div class="section-shell">
+        <div class="section-core">
+          <div class="section-head">
+            <div>
+              <div class="eyebrow">cron gate</div>
+              <h2>Scheduled autonomy.</h2>
+            </div>
+            <span class="status status-stale" id="cron-count">0</span>
+          </div>
+          <div id="cron-gate" class="atlas-list"></div>
+          <div id="guideposts" class="guidepost-list"></div>
+        </div>
+      </div>
+    </section>
+
     <footer class="footer">
-      <span>Polling <code>/api/status</code> every 10s. Freshness is measured from adapter evidence, not assumed health.</span>
+      <span>Polling <code>/api/status</code> and <code>/api/labyrinth</code>. Actions are fixed registry entries, not shell input.</span>
       <span id="footer-mode">mode: unknown</span>
     </footer>
   </main>
@@ -730,6 +1082,8 @@
   <script>
     const initialData = {{ initial_data | tojson }};
     const fallbackOrder = ["hermes", "droids", "telegram", "gbrain", "workflows", "alerts"];
+    let currentLabyrinth = null;
+    let selectedCrossingId = null;
 
     function escapeHtml(value) {
       return String(value ?? "")
@@ -878,6 +1232,164 @@
       }).join("");
     }
 
+    function renderActions(payload) {
+      const actions = payload.actions || [];
+      const target = document.getElementById("action-list");
+      target.innerHTML = actions.map((action) => `
+        <button class="action-button" type="button" data-action-id="${escapeHtml(action.id)}">
+          <span>
+            <strong>${escapeHtml(action.label)}</strong>
+            <span>${escapeHtml(action.description)}</span>
+          </span>
+          <span class="action-icon">/</span>
+        </button>
+      `).join("");
+      target.querySelectorAll("button[data-action-id]").forEach((button) => {
+        button.addEventListener("click", () => runAction(button.dataset.actionId));
+      });
+    }
+
+    function renderActionResult(event) {
+      const result = document.getElementById("action-result");
+      const status = event.status || "unknown";
+      const output = event.stderr_preview || event.stdout_preview || "No output captured.";
+      result.innerHTML = `
+        <span class="status status-${status === "succeeded" ? "healthy" : "degraded"}">${escapeHtml(status)}</span>
+        <span class="source">${escapeHtml(event.label || event.action_id || "action")} / exit ${escapeHtml(event.exit_code)} / ${escapeHtml(event.duration_ms)}ms</span>
+        <pre>${escapeHtml(output)}</pre>
+      `;
+    }
+
+    async function runAction(actionId) {
+      const buttons = [...document.querySelectorAll(".action-button")];
+      buttons.forEach((button) => button.disabled = true);
+      document.getElementById("action-result").innerHTML = `<span class="status status-stale">running</span><span class="source">${escapeHtml(actionId)}</span>`;
+      try {
+        const response = await fetch(`/api/actions/${encodeURIComponent(actionId)}`, { method: "POST", cache: "no-store" });
+        const event = await response.json();
+        renderActionResult(event);
+        await Promise.all([refresh(), refreshLabyrinth()]);
+      } catch (error) {
+        renderActionResult({ status: "failed", label: actionId, exit_code: "network", duration_ms: 0, stderr_preview: error.message });
+      } finally {
+        buttons.forEach((button) => button.disabled = false);
+      }
+    }
+
+    function renderJourneys(payload) {
+      const target = document.getElementById("journey-strip");
+      const journeys = payload.journeys || [];
+      target.innerHTML = journeys.map((journey) => `
+        <button class="journey-chip" type="button" data-journey-id="${escapeHtml(journey.id)}">
+          <strong>${escapeHtml(journey.title)}</strong>
+          <small>${escapeHtml(journey.source)} / ${escapeHtml(journey.status)}</small>
+          <small>${escapeHtml(journey.summary || "")}</small>
+        </button>
+      `).join("");
+      target.querySelectorAll("button[data-journey-id]").forEach((button) => {
+        button.addEventListener("click", () => {
+          const first = (currentLabyrinth?.crossings || []).find((item) => item.journey_id === button.dataset.journeyId);
+          if (first) {
+            selectedCrossingId = first.id;
+            renderCrossings(currentLabyrinth);
+          }
+        });
+      });
+    }
+
+    function renderInspector(crossing) {
+      const target = document.getElementById("inspector");
+      if (!crossing) {
+        target.innerHTML = `<span class="source">Select a crossing to inspect evidence.</span>`;
+        return;
+      }
+      const evidence = crossing.evidence || {};
+      target.innerHTML = `
+        <span class="status status-${crossing.status === "succeeded" ? "healthy" : escapeHtml(crossing.status || "stale")}">${escapeHtml(crossing.status || "unknown")}</span>
+        <h2>${escapeHtml(crossing.label)}</h2>
+        <span class="source">${escapeHtml(crossing.type)} / ${escapeHtml(crossing.thread)} / ${escapeHtml(crossing.timestamp)}</span>
+        <p>${escapeHtml(crossing.summary || "No summary available.")}</p>
+        <pre>${escapeHtml(JSON.stringify(evidence, null, 2))}</pre>
+      `;
+    }
+
+    function renderCrossings(payload) {
+      const crossings = payload.crossings || [];
+      if (!selectedCrossingId && crossings.length) selectedCrossingId = crossings[crossings.length - 1].id;
+      const selected = crossings.find((item) => item.id === selectedCrossingId) || crossings[crossings.length - 1];
+      if (selected) selectedCrossingId = selected.id;
+      const target = document.getElementById("crossing-list");
+      target.innerHTML = crossings.slice().reverse().map((crossing) => `
+        <button class="crossing ${crossing.id === selectedCrossingId ? "selected" : ""}" type="button" data-crossing-id="${escapeHtml(crossing.id)}">
+          <span class="thread">${escapeHtml(crossing.thread)}</span>
+          <span>
+            <strong>${escapeHtml(crossing.label)}</strong>
+            <small>${escapeHtml(crossing.type)} / ${escapeHtml(crossing.summary || "")}</small>
+          </span>
+          <span class="status status-${crossing.status === "succeeded" ? "healthy" : escapeHtml(crossing.status || "stale")}">${escapeHtml(crossing.status || "unknown")}</span>
+        </button>
+      `).join("");
+      target.querySelectorAll("button[data-crossing-id]").forEach((button) => {
+        button.addEventListener("click", () => {
+          selectedCrossingId = button.dataset.crossingId;
+          renderCrossings(currentLabyrinth);
+        });
+      });
+      renderInspector(selected);
+    }
+
+    function renderGuideposts(payload) {
+      const guideposts = payload.guideposts || [];
+      const target = document.getElementById("guideposts");
+      if (!guideposts.length) {
+        target.innerHTML = `<div class="guidepost"><strong>No guideposts</strong><p>No degraded crossings in the current map.</p></div>`;
+        return;
+      }
+      target.innerHTML = guideposts.slice(0, 8).map((item) => `
+        <div class="guidepost">
+          <strong>${escapeHtml(item.title)}</strong>
+          <p>${escapeHtml(item.summary)}</p>
+        </div>
+      `).join("");
+    }
+
+    function renderAtlas(payload) {
+      const skills = payload.skills || [];
+      const cron = payload.cron || [];
+      document.getElementById("skill-count").textContent = String(skills.length);
+      document.getElementById("cron-count").textContent = String(cron.filter((item) => item.status === "configured").length);
+      document.getElementById("skill-atlas").innerHTML = skills.slice(0, 12).map((skill) => `
+        <div class="atlas-item">
+          <strong>${escapeHtml(skill.name)}</strong>
+          <p>${escapeHtml(skill.namespace)} / ${escapeHtml(skill.description)}</p>
+        </div>
+      `).join("") || `<div class="atlas-item"><strong>No skills found</strong><p>Skill roots were not readable.</p></div>`;
+      document.getElementById("cron-gate").innerHTML = cron.map((item) => `
+        <div class="atlas-item">
+          <strong>${escapeHtml(item.name)}</strong>
+          <p>${escapeHtml(item.status)} / ${escapeHtml(item.path)}</p>
+        </div>
+      `).join("");
+    }
+
+    function renderLabyrinth(payload) {
+      currentLabyrinth = payload;
+      renderActions(payload);
+      renderJourneys(payload);
+      renderCrossings(payload);
+      renderAtlas(payload);
+      renderGuideposts(payload);
+    }
+
+    async function refreshLabyrinth() {
+      try {
+        const response = await fetch("/api/labyrinth", { cache: "no-store" });
+        if (response.ok) renderLabyrinth(await response.json());
+      } catch (error) {
+        document.getElementById("inspector").innerHTML = `<div class="error">${escapeHtml(error.message)}</div>`;
+      }
+    }
+
     function render(payload) {
       document.getElementById("nav-updated").textContent = `updated ${payload.overview?.timestamp || "unknown"}`;
       document.getElementById("footer-mode").textContent = `mode: ${payload.overview?.mode || "unknown"} / ${payload.overview?.version || "unknown"}`;
@@ -944,7 +1456,10 @@
     }
 
     render(initialData);
+    refreshLabyrinth();
+    document.getElementById("labyrinth-refresh").addEventListener("click", refreshLabyrinth);
     setInterval(refresh, 10000);
+    setInterval(refreshLabyrinth, 15000);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add registry-only executable actions with redacted audit logging under ~/.hero_core/actions.jsonl
- add Labyrinth-inspired journeys, crossings, guideposts, skill atlas, and cron gate APIs
- upgrade the dashboard UI with action dock, timeline inspector, mobile-safe layouts, and live action results
- restore launcher executable bit and support HERO_DASHBOARD_PORT/PORT

## Validation
- python3 -m py_compile web_dashboard.py config.py
- python3 -m pytest -q tests/test_web_dashboard_reboot.py
- bash -n launch_web_dashboard.sh
- git diff --check
- live curl smoke: /api/status, /api/actions, /api/labyrinth, POST /api/actions/compile_dashboard
- Playwright desktop/mobile checks: 6 cards, 5 actions, populated crossings/journeys, action execution, no page-level horizontal overflow
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chipoto69/herodash/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added operator dashboard with action controls to execute server operations, displaying results and execution history
  * Introduced labyrinth map visualization featuring journeys, crossing navigation, and detailed evidence inspector for analysis
  * Added inventory displays for available skills and configured cron entries with live performance counters
  * Made dashboard port configurable via environment variable for flexible deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->