### PR TITLE
Make Hero dashboard launcher daemon-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Requirements:
   - `~/ORGANIZED/ACTIVE_PROJECTS/ARSENAL/WORKFLOWS`
   - `~/wiki/queries/grok420system.md`
 
-Start the dashboard:
+Start the dashboard in the background:
 
 ```bash
 ./launch_web_dashboard.sh start
@@ -89,6 +89,12 @@ Other useful commands:
 ./launch_web_dashboard.sh status
 ./launch_web_dashboard.sh logs
 ./launch_web_dashboard.sh stop
+```
+
+For an attached interactive run, use:
+
+```bash
+./launch_web_dashboard.sh foreground
 ```
 
 You can also run the app directly:
@@ -138,7 +144,7 @@ Status semantics:
 
 ```bash
 python3 -m py_compile web_dashboard.py
-pytest -q tests/test_web_dashboard_reboot.py
+pytest -q tests/test_web_dashboard_reboot.py tests/test_launcher_contract.py
 bash -n launch_web_dashboard.sh
 ```
 

--- a/README_OPTIMIZED.md
+++ b/README_OPTIMIZED.md
@@ -15,10 +15,11 @@ A lot of legacy docs and muscle memory still point at “optimized dashboard” 
 ## Reboot-first usage
 
 ```bash
-./launch_web_dashboard.sh start
+./launch_web_dashboard.sh start      # background daemon for normal ops/smoke checks
 ./launch_web_dashboard.sh status
 ./launch_web_dashboard.sh logs
 ./launch_web_dashboard.sh stop
+./launch_web_dashboard.sh foreground # attached interactive run
 ```
 
 Direct launch:
@@ -55,9 +56,11 @@ Added as primary framing:
 
 ```bash
 python3 -m py_compile web_dashboard.py
-pytest -q tests/test_web_dashboard_reboot.py
+pytest -q tests/test_web_dashboard_reboot.py tests/test_launcher_contract.py
+./launch_web_dashboard.sh start
 curl http://127.0.0.1:8080/api/healthz
 curl http://127.0.0.1:8080/api/readiness
+./launch_web_dashboard.sh stop
 ```
 
 ## Legacy note

--- a/launch_web_dashboard.sh
+++ b/launch_web_dashboard.sh
@@ -148,6 +148,7 @@ pid_matches_dashboard() {
 
 # Start web dashboard
 start_web_dashboard() {
+    local attached="${1:-false}"
     log "Starting Hero Web Dashboard..."
     
     # Set environment variables
@@ -183,7 +184,11 @@ start_web_dashboard() {
         echo "  Readiness:      http://localhost:$HERO_DASHBOARD_PORT/api/readiness"
         echo ""
         echo -e "${GREEN}Dashboard is running with honest subsystem probes${NC}"
-        echo -e "${YELLOW}Press Ctrl+C to stop or use './launch_web_dashboard.sh stop'${NC}"
+        if [[ "$attached" == "true" ]]; then
+            echo -e "${YELLOW}Press Ctrl+C to stop or use './launch_web_dashboard.sh stop'${NC}"
+        else
+            echo "Use './launch_web_dashboard.sh status' to inspect it, or './launch_web_dashboard.sh stop' to stop it"
+        fi
         
         return 0
     else
@@ -334,7 +339,8 @@ usage() {
     echo "Usage: $0 [COMMAND]"
     echo ""
     echo "Commands:"
-    echo "  start       Start web dashboard (default)"
+    echo "  start       Start web dashboard in the background (default)"
+    echo "  foreground  Start web dashboard and keep it attached until Ctrl+C"
     echo "  stop        Stop web dashboard"
     echo "  restart     Restart web dashboard"
     echo "  status      Show dashboard status"
@@ -392,8 +398,14 @@ main() {
             create_directories
             check_dependencies
             check_agent_status
-            if start_web_dashboard; then
-                # Keep script running in foreground
+            start_web_dashboard
+            ;;
+        foreground)
+            header
+            create_directories
+            check_dependencies
+            check_agent_status
+            if start_web_dashboard true; then
                 echo ""
                 echo -e "${GREEN}Web dashboard is running. Press Ctrl+C to stop.${NC}"
                 wait
@@ -423,7 +435,7 @@ main() {
             check_dependencies
             check_agent_status
             start_analytics
-            if start_web_dashboard; then
+            if start_web_dashboard true; then
                 open_browser
                 echo ""
                 echo -e "${GREEN}Full Hero dashboard stack running. Press Ctrl+C to stop.${NC}"

--- a/tests/test_launcher_contract.py
+++ b/tests/test_launcher_contract.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LAUNCHER = ROOT / "launch_web_dashboard.sh"
+
+
+def _case_body(command: str) -> str:
+    text = LAUNCHER.read_text()
+    pattern = rf"\n\s*{re.escape(command)}\)\n(?P<body>.*?)(?=\n\s*[a-zA-Z_|-]+\)|\n\s*\*\))"
+    match = re.search(pattern, text, flags=re.DOTALL)
+    assert match, f"missing {command}) case in launcher"
+    return match.group("body")
+
+
+def test_launcher_start_returns_after_daemonizing_dashboard():
+    body = _case_body("start")
+
+    assert "start_web_dashboard" in body
+    assert "wait" not in body, "start must return so status/logs/stop and smoke curls can run"
+
+
+def test_launcher_foreground_keeps_process_attached_for_interactive_use():
+    body = _case_body("foreground")
+
+    assert "start_web_dashboard true" in body
+    assert "wait" in body
+    assert "Press Ctrl+C" in body
+
+
+def test_launcher_only_prints_ctrl_c_hint_for_attached_runs():
+    text = LAUNCHER.read_text()
+
+    assert "local attached=" in text
+    assert "if [[ \"$attached\" == \"true\" ]]" in text
+    assert "start_web_dashboard true" in _case_body("foreground")
+    assert "start_web_dashboard true" in _case_body("full")
+    assert "start_web_dashboard true" not in _case_body("start")
+
+
+def test_launcher_full_keeps_process_attached_after_starting_analytics():
+    body = _case_body("full")
+
+    assert "start_analytics" in body
+    assert "start_web_dashboard true" in body
+    assert "open_browser" in body
+    assert "wait" in body


### PR DESCRIPTION
## Summary
- make ./launch_web_dashboard.sh start daemonize and return for smoke checks/operator control
- add ./launch_web_dashboard.sh foreground for attached interactive runs
- preserve full mode as attached and add launcher contract regression tests
- update docs for the new launcher contract

## Test plan
- python3 -m py_compile web_dashboard.py config.py
- bash -n launch_web_dashboard.sh
- python3 -m pytest -q
- ./launch_web_dashboard.sh start; curl /api/healthz, /api/status, /api/readiness; ./launch_web_dashboard.sh stop; verify port 8080 closes

Note: /api/readiness currently returns degraded on this machine because Hermes webapi/workspace or Telegram freshness are not fully healthy; dashboard liveness/status smoke checks pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chipoto69/herodash/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `foreground` mode for interactive, attached dashboard runs alongside existing background startup.

* **Documentation**
  * Updated startup instructions to distinguish background daemon and foreground interactive modes.
  * Expanded validation procedures with additional test coverage.

* **Tests**
  * Added comprehensive launcher behavior validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->